### PR TITLE
Prevent rapid exit without waiting for the user to read error (if anything throws)

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Program.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Program.cs
@@ -260,6 +260,11 @@ namespace SharePoint.Modernization.Scanner
                         scannerTelemetry.LogScanDone(duration);
                     }
                 }
+                catch (Exception Ex)
+                {
+                    Console.WriteLine("Error executing scan: \n"+Ex.Message+ "\n Press any key to continue");
+                    Console.ReadKey();
+                }
                 finally
                 {
                     if (scannerTelemetry != null)


### PR DESCRIPTION
Type
x  Bug Fix
   New Feature
   Sample

What is in this Pull Request ?

If code runs into an exception during execution (scanning , perms, etc) the console window just exists.
Added a general catch in the man calling function to allow the error to be displayed and read